### PR TITLE
Refactoring: Use block instead of proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,32 +21,30 @@ require "lambda_builder"
 
 runtime = LambdaBuilder::Runtime.new
 
-runtime.register_handler("httpevent",
-  ->(input : JSON::Any) {
-    req = LambdaBuilder::Util::LambdaHttpRequest.new(input)
-    user = req.query_params.fetch("hello", "World")
-    response = LambdaBuilder::Util::LambdaHttpResponse.new(200, "Hello #{user} from Crystal")
-    # not super efficient, serializing to JSON string and then parsing, simplify this
-    return JSON.parse response.to_json
-  }
-)
+runtime.register_handler("httpevent") do |input|
+  req = LambdaBuilder::Util::LambdaHttpRequest.new(input)
+  user = req.query_params.fetch("hello", "World")
+  response = LambdaBuilder::Util::LambdaHttpResponse.new(200, "Hello #{user} from Crystal")
+  # not super efficient, serializing to JSON string and then parsing, simplify this
+  JSON.parse response.to_json
+end
 
-runtime.register_handler("scheduledevent",
-  ->(input : JSON::Any) {
-    runtime.logger.debug("Hello from scheduled event, input: #{input}")
-    return JSON.parse "{}"
-  }
-)
+runtime.register_handler("scheduledevent") do |input|
+  runtime.logger.debug("Hello from scheduled event, input: #{input}")
+  JSON.parse "{}"
+end
 
-runtime.register_handler("snsevent",
-  ->(input : JSON::Any) {
-    runtime.logger.info("SNSEvent input: #{input}")
-    return JSON.parse "{}"
-  }
-)
+runtime.register_handler("snsevent") do |input|
+  runtime.logger.info("SNSEvent input: #{input}")
+  JSON.parse "{}"
+end
 
 runtime.run
 ```
+
+The `input` variable is of type `JSON::Any` and represents the JSON handed over by the lambda event.
+
+There is a helper class to create a HTTP request from the input, no need to do that manually.
 
 ## Deployment
 

--- a/example/src/bootstrap.cr
+++ b/example/src/bootstrap.cr
@@ -2,28 +2,22 @@ require "lambda_builder"
 
 runtime = LambdaBuilder::Runtime.new
 
-runtime.register_handler("httpevent",
-  ->(input : JSON::Any) {
-    req = LambdaBuilder::Util::LambdaHttpRequest.new(input)
-    user = req.query_params.fetch("hello", "World")
-    response = LambdaBuilder::Util::LambdaHttpResponse.new(200, "Hello #{user} from Crystal")
-    # not super efficient, serializing to JSON string and then parsing, simplify this
-    return JSON.parse response.to_json
-  }
-)
+runtime.register_handler("httpevent") do |input|
+  req = LambdaBuilder::Util::LambdaHttpRequest.new(input)
+  user = req.query_params.fetch("hello", "World")
+  response = LambdaBuilder::Util::LambdaHttpResponse.new(200, "Hello #{user} from Crystal")
+  # not super efficient, serializing to JSON string and then parsing, simplify this
+  JSON.parse response.to_json
+end
 
-runtime.register_handler("scheduledevent",
-  ->(input : JSON::Any) {
-    runtime.logger.debug("Hello from scheduled event, input: #{input}")
-    return JSON.parse "{}"
-  }
-)
+runtime.register_handler("scheduledevent") do |input|
+  runtime.logger.debug("Hello from scheduled event, input: #{input}")
+  JSON.parse "{}"
+end
 
-runtime.register_handler("snsevent",
-  ->(input : JSON::Any) {
-    runtime.logger.info("SNSEvent input: #{input}")
-    return JSON.parse "{}"
-  }
-)
+runtime.register_handler("snsevent") do |input|
+  runtime.logger.info("SNSEvent input: #{input}")
+  JSON.parse "{}"
+end
 
 runtime.run


### PR DESCRIPTION
This makes the code more readable and prevents rewriting the same
proc over and over again.