### PR TITLE
Experiment converting JSON::Aany to string

### DIFF
--- a/spec/lambda_builder/http_request_spec.cr
+++ b/spec/lambda_builder/http_request_spec.cr
@@ -16,6 +16,14 @@ describe Lambda::Builder::HTTPRequest do
     req.query_params["test"].should eq "bar"
   end
 
+  it "parses api gateway v2 (HTTP gateway)" do
+    ENV["_HANDLER"] = "foo"
+    input = JSON.parse(request_body_v2)
+    req = Lambda::Builder::HTTPRequest.new(input)
+    req.method.should eq "OPTIONS"
+    req.path.should eq "/hi"
+  end
+
   it "works with empty body and query string" do
     body = %q({ "path" : "/test", "httpMethod" : "GET", "headers" : { "key": "value" }, "requestContext" : {} })
     response = HTTP::Client::Response.new(200, body, HTTP::Headers.new)

--- a/spec/lambda_builder/runtime_spec.cr
+++ b/spec/lambda_builder/runtime_spec.cr
@@ -27,7 +27,7 @@ describe Lambda::Builder::Runtime do
     runtime = Lambda::Builder::Runtime.new
     # handler = do |_input| JSON.parse Lambda::Builder::HTTPResponse.new(200).to_json end
     runtime.register_handler("my_handler") do |_input|
-      JSON.parse(%q({ "foo" : "bar"}))
+      %q({ "foo" : "bar"})
     end
     runtime.handlers["my_handler"].should_not be_nil
   end
@@ -44,7 +44,7 @@ describe Lambda::Builder::Runtime do
 
     runtime = Lambda::Builder::Runtime.new
     runtime.register_handler("my_handler") do
-      JSON.parse(%q({ "foo" : "bar" }))
+      %q({ "foo" : "bar" })
     end
     runtime.process_handler
   end
@@ -67,7 +67,7 @@ describe Lambda::Builder::Runtime do
     runtime.register_handler("my_handler") do
       response = Lambda::Builder::HTTPResponse.new(200, "text body")
       response.headers["Content-Type"] = "application/text"
-      JSON.parse response.to_json
+      response.to_json
     end
     runtime.process_handler
   end
@@ -102,7 +102,7 @@ describe Lambda::Builder::Runtime do
 
     runtime = Lambda::Builder::Runtime.new
     runtime.register_handler("my_handler") do
-      JSON.parse "{}"
+      "{}"
     end
     runtime.process_handler
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -116,3 +116,58 @@ def request_body
   }
 END
 end
+
+def request_body_v2
+  <<-END
+    {
+    "version": "2.0",
+    "routeKey": "OPTIONS /{proxy+}",
+    "rawPath": "/hi",
+    "rawQueryString": "",
+    "headers": {
+      "accept": "*/*",
+      "accept-encoding": "gzip, deflate, br",
+      "accept-language": "en-US,en;q=0.9",
+      "access-control-request-headers": "authorization,content-type",
+      "access-control-request-method": "POST",
+      "content-length": "0",
+      "content-type": "application/x-www-form-urlencoded",
+      "forwarded": "by=0.0.0.0;for=0.0.0.0;host=local.dev;proto=https",
+      "host": "local.dev",
+      "origin": "https://local.dev",
+      "referer": "https://local.dev/",
+      "sec-fetch-dest": "empty",
+      "sec-fetch-mode": "cors",
+      "sec-fetch-site": "same-site",
+      "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/0.0.0.0 Safari/537.36",
+      "via": "HTTP/1.1 AmazonAPIGateway",
+      "x-amzn-trace-id": "Self=1-60ad1af6-6041ce5335bd44ad26b42c70;Root=1-60ad2af6-7bbc041f64b16ac44ad97952",
+      "x-forwarded-for": "0.0.0.0",
+      "x-forwarded-port": "443",
+      "x-forwarded-proto": "https"
+    },
+    "pathParameters": {
+      "proxy": "score"
+    },
+    "requestContext": {
+      "routeKey": "OPTIONS /{proxy+}",
+      "accountId": "5555555555",
+      "stage": "$default",
+      "requestId": "f5Emhi3LIAMEM7A=",
+      "apiId": "xxxxx",
+      "domainName": "local.dev",
+      "domainPrefix": "local",
+      "time": "25/May/2021:15:42:46 +0000",
+      "timeEpoch": 1621957366418,
+      "http": {
+        "method": "OPTIONS",
+        "path": "/hi",
+        "protocol": "HTTP/1.1",
+        "sourceIp": "0.0.0.0",
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/0.0.0.0 Safari/537.36"
+      }
+    },
+    "isBase64Encoded": false
+  }
+END
+end

--- a/src/lambda_builder/runtime.cr
+++ b/src/lambda_builder/runtime.cr
@@ -7,7 +7,7 @@ module Lambda::Builder
   class Runtime
     getter host : String
     getter port : Int16
-    getter handlers : Hash(String, (JSON::Any -> JSON::Any)) = Hash(String, (JSON::Any -> JSON::Any)).new
+    getter handlers : Hash(String, (String -> String)) = Hash(String, (String -> String)).new
     Log = ::Log.for(self)
 
     def initialize
@@ -18,7 +18,7 @@ module Lambda::Builder
     end
 
     # Associate the block/proc to the function name
-    def register_handler(name : String, &handler : JSON::Any -> JSON::Any)
+    def register_handler(name : String, &handler : String -> String)
       self.handlers[name] = handler
     end
 
@@ -38,7 +38,7 @@ module Lambda::Builder
       end
     end
 
-    def _process_request(proc : Proc(JSON::Any, JSON::Any))
+    def _process_request(proc : Proc(String, String))
       client = HTTP::Client.new(host: @host, port: @port)
 
       begin
@@ -48,11 +48,12 @@ module Lambda::Builder
         aws_request_id = response.headers["Lambda-Runtime-Aws-Request-Id"]
         base_url = "/2018-06-01/runtime/invocation/#{aws_request_id}"
 
-        input = JSON.parse response.body
-        body = proc.call input
+        # input = JSON.parse response.body
+        # body = proc.call input
+        body = proc.call response.body
 
         Log.info { "preparing body #{body}" }
-        response = client.post("#{base_url}/response", body: body.to_json)
+        response = client.post("#{base_url}/response", body: body)
         Log.debug { "response invocation response #{response.status_code} #{response.body}" }
       rescue ex
         body = %Q({ "statusCode": 500, "body" : "#{ex.message}" })


### PR DESCRIPTION
Hey @spinscale, 

I've been using your project to work on a serverless lambda project. Thanks!

I'm bumping into an issue and figured I'd open a pull request to explore some options.

The issue:

The current `Lambda::Builder::HTTPRequest` class doesn't support AWS HTTP ApiGateway's request structure (https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html)

In the pull request I put an example spec 'parses api gateway v2 (HTTP gateway)' that is failing to parse.

Idea 1) 

I like the idea behind supplying `Lambda::Builder::HTTPRequest`... I think overall it may be a bit limitting.

An alternative approach I'm thinking through is to leverage JSON serializable event objects that can be used to handle a wide range of lambda request structures.

I come from a go backgroung and this is the approach that aws takes there. For example here are all the event definitions: https://github.com/aws/aws-lambda-go/blob/5d6413264f82afaa7587b56e3f09f1422c898c68/events/apigw.go#L6

An example class would look like:

```
module AWSLambdaCrystal::Events
  class APIGatewayV2HTTPResponse
    include JSON::Serializable

    @[JSON::Field(key: "statusCode")]
    property status_code : Int32

    @[JSON::Field(key: "headers")]
    property headers : Hash(String, String)

    @[JSON::Field(key: "multiValueHeaders")]
    property headers : Hash(String, Array(String))

    @[JSON::Field(key: "body")]
    property body : String

    @[JSON::Field(key: "body")]
    property is_base64_encoded : Bool?

    @[JSON::Field(key: "cookies")]
    property cookies : Array(String)
  end
end
```

In the case of go the handler will automatically serialize the incoming json into the appropriate type connected to the handler: https://github.com/aws/aws-lambda-go/blob/5d6413264f82afaa7587b56e3f09f1422c898c68/lambda/handler.go#L83

I kinda like that approach.

That approach also still leaves open the `Lambda::Builder::HTTPRequest` concept where you make the api gateway request look like an HTTP request.

In order to gain that same benefit you can instead construct `Lambda::Builder::HTTPRequest` from one of the serialized classes.

Api Gateway Json => Serialized to event object of appropriate type => Lambda::Builder::HTTPRequest (in the case of the api gateway events).

I'm still playing with this idea and trying to make it have a good feel to it wrt connecting the handler...

Option 2)

Another option is to just change the JSON::Any to String and let the user do whatever they want. This doesn't feel as slick to me but is easier. That is what I changed in this pull request.

If you get the chance please let me know your thoughts on either approach (or any others).