### PR TITLE
Upgrade crystal and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ example/shard.lock
 example/lib/
 example/bin/
 example/.serverless/
+.vscode
 
 # Libraries don't need dependency lock
 # Dependencies will be locked in applications that use them

--- a/example/Makefile
+++ b/example/Makefile
@@ -9,7 +9,7 @@ endif
 
 build:
 	[ -d bin ] || mkdir bin
-	docker run --rm -it -v $(CURDIR):/app -w /app 84codes/crystal:1.6.2-alpine /bin/sh -c "crystal build src/bootstrap.cr -o bin/bootstrap --release --static --no-debug ; strip bin/bootstrap"
+	docker run --rm -it -v $(CURDIR):/app -w /app crystallang/crystal:1.6.2-alpine /bin/sh -c "crystal build src/bootstrap.cr -o bin/bootstrap --release --static --no-debug ; strip bin/bootstrap"
 	zip -j bootstrap.zip bin/bootstrap
 
 dependencies:

--- a/example/Makefile
+++ b/example/Makefile
@@ -9,7 +9,7 @@ endif
 
 build:
 	[ -d bin ] || mkdir bin
-	docker run --rm -it -v $(CURDIR):/app -w /app durosoft/crystal-alpine:0.30.1 /bin/sh -c "crystal build src/bootstrap.cr -o bin/bootstrap --release --static --no-debug ; strip bin/bootstrap"
+	docker run --rm -it -v $(CURDIR):/app -w /app 84codes/crystal:1.6.2-alpine /bin/sh -c "crystal build src/bootstrap.cr -o bin/bootstrap --release --static --no-debug ; strip bin/bootstrap"
 	zip -j bootstrap.zip bin/bootstrap
 
 dependencies:

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -10,9 +10,9 @@ package:
 functions:
   httpevent:
     handler: httpevent
+    memorySize: 128
     events:
       - http:
-          memorySize: 128
           path: hello
           method: get
 

--- a/example/shard.yml
+++ b/example/shard.yml
@@ -9,6 +9,6 @@ dependencies:
     github: spinscale/crystal-aws-lambda
     branch: main
 
-crystal: 0.25.0
+crystal: 1.6.2
 
 license: MIT

--- a/example/shard.yml
+++ b/example/shard.yml
@@ -3,11 +3,12 @@ version: 0.1.0
 
 authors:
   - Alexander Reelsen <alexander@reelsen.net>
-
+  - Josephine Pfeiffer <hi@josie.lol>
+  
 dependencies:
   lambda_builder:
-    github: pfeifferj/crystal-aws-lambda
-    branch: upgrade-crystal-and-dependencies
+    github: spinscale/crystal-aws-lambda
+    branch: main
 
 crystal: 1.6.2
 

--- a/example/shard.yml
+++ b/example/shard.yml
@@ -6,8 +6,8 @@ authors:
 
 dependencies:
   lambda_builder:
-    github: spinscale/crystal-aws-lambda
-    branch: main
+    github: pfeifferj/crystal-aws-lambda
+    branch: upgrade-crystal-and-dependencies
 
 crystal: 1.6.2
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,17 +1,18 @@
 name: lambda_builder
-version: 0.1.1
+version: 0.1.2
 
 authors:
   - Alexander Reelsen <alexander@reelsen.net>
+  - Josephine Pfeiffer <hi@josie.lol>
 
 development_dependencies:
   webmock:
     github: manastech/webmock.cr
     version: 0.14.0
   ameba:
-    github: veelenga/ameba
-    version: 0.14.3
+    github: crystal-ameba/ameba
+    version: 1.3.1
 
-crystal: 1.0.0
+crystal: 1.6.2
 
 license: MIT

--- a/spec/lambda_builder/runtime_spec.cr
+++ b/spec/lambda_builder/runtime_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 
 def mock_next_invocation(body : String)
   WebMock.stub(:get, "http://localhost/2018-06-01/runtime/invocation/next")
-    .to_return(status: 200, body: body, headers: {"Lambda-Runtime-Aws-Request-Id" => "54321", "Lambda-Runtime-Trace-Id" => "TRACE-ID", "Content-Type": "application/json"})
+    .to_return(status: 200, body: body, headers: {"Lambda-Runtime-Aws-Request-Id" => "54321", "Lambda-Runtime-Trace-Id" => "TRACE-ID", "Content-Type" => "application/json"})
 end
 
 describe Lambda::Builder::Runtime do


### PR DESCRIPTION
Change log:
* bumped crystal version from `0.25.0` to `1.6.2`
* changed docker image reference in demo `Makefile` to the official crystallang `1.6.2-alpine` image
* corrected syntax error in demo `serverless.yml`, which previously caused a warning on deploy
* changed ameba shard reference to official crystallang shard and bumped version from `0.14.3` to `1.3.1`
* corrected syntax error in runtime spec ('key: value' syntax in a hash literal)

deployed demo: [https://5frl2mg1cg.execute-api.us-east-1.amazonaws.com/dev/hello](https://5frl2mg1cg.execute-api.us-east-1.amazonaws.com/dev/hello)